### PR TITLE
Fix handling of relative paths in checkout output

### DIFF
--- a/myProject.py
+++ b/myProject.py
@@ -66,5 +66,3 @@ def extract_repo(bug_info, folder):
 
     delete_cmd = "rm -r " + os.path.join(folder, 'test_repositories')
     sp.call(delete_cmd, shell=True, stdout=sp.DEVNULL, stderr=sp.STDOUT)
-
-    os.chdir(os.listdir("./")[0])


### PR DESCRIPTION
It is not necessary to change the directory at the end of `extract_repo` since all subsequent `subprocess.call` invocations have the proper `cwd` parameter set. Removing this directory change allows the script to work with relative paths as output. If the directory is changed to the project directory, then `shutil.copytree(param_dict["output"], os.path.join(param_dict["output"], 'tmp-' + bug_info['fixed_commit_id']))` won't find the required directory and results in an error:

```
$ python main.py -p composer--composer -b 1 -t checkout -v buggy -o ../tmp
Extracting ... project = composer/composer bug_no = 1
Checking out ... project = composer/composer bug_no = 1
Traceback (most recent call last):
  File "bugsPHP/main.py", line 15, in <module>
    myProject.checkout(param_dict)
  File "bugsPHP/myProject.py", line 20, in checkout
    shutil.copytree(param_dict["output"], os.path.join(param_dict["output"], 'tmp-' + bug_info['fixed_commit_id']))
  File "shutil.py", line 571, in copytree
    with os.scandir(src) as itr:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '../tmp'
```