### PR TITLE
Add output directory for metadata extraction

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import subprocess as sp
 
 SCRIPTDIR = os.path.abspath(os.path.dirname(sys.argv[0]))
 if(not os.path.exists(os.path.join(SCRIPTDIR,'bug_metadata.json'))):
-    extract_cmd = "7z e " + SCRIPTDIR + "/bug_metadata.7z "
+    extract_cmd = "7z e " + SCRIPTDIR + "/bug_metadata.7z " + "-o" + SCRIPTDIR
     sp.call(extract_cmd, shell=True, stdout=sp.DEVNULL, stderr=sp.STDOUT)
 
 param_dict = argument_parser.arg_parser()


### PR DESCRIPTION
The `bug_metadata.7z` file is extracted into the current working directory from which the user invokes the `main.py` script. An output flag has been added to the `7z` command to ensure that `bug_metadata.7z` is always extracted into the root directory of `bugsPHP`.

Currently, everything works fine as long as the user invokes `main.py` from the root directory of `bugsPHP` for the first time:

```bash
$ cd bugsPHP
$ python main.py
usage: main.py [-h] -p
               {googleapis--google-api-php-client,PHP-CS-Fixer--PHP-CS-Fixer,PHPOffice--PhpSpreadsheet,briannesbitt--Carbon,cakephp--cakephp,w7corp--easywechat,Seldaek--monolog,spatie--laravel-permission,symfony--symfony,doctrine--orm,doctrine--dbal,laravel--framework,magento--magento2,nikic--PHP-Parser,composer--composer}
               -b BUG_NO -t {checkout,install,test,failing-test-only}
               [-c TEST_CASE] -v {buggy,fixed} [-o OUTPUT]
main.py: error: the following arguments are required: -p/--project, -b/--bug-no, -t/--task, -v/--version
```

However, if the user invokes the script from a different location, the script will still search for the extracted file in the root directory of `bugsPHP`. Since the file is extracted to the user’s current directory, the script will not find the extracted file:

```bash
$ cd ..
$ python bugsPHP/main.py
Traceback (most recent call last):
  File "bugsPHP/main.py", line 13, in <module>
    param_dict = argument_parser.arg_parser()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "bugsPHP/argument_parser.py", line 9, in arg_parser
    parser.add_argument('-p', '--project',  required=True, type=str, choices=get_projects(), help='')
                                                                             ^^^^^^^^^^^^^^
  File "bugsPHP/argument_parser.py", line 30, in get_projects
    bug_file = open(os.path.join(SCRIPTDIR, "bug_metadata.json"), "r")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'bugsPHP/bug_metadata.json'
```
