### PR TITLE
Remove unnecessary chdir

### DIFF
--- a/myProject.py
+++ b/myProject.py
@@ -56,7 +56,6 @@ def extract_repo(bug_info, folder):
         sp.call(rm_cmd, shell=True, stdout=sp.DEVNULL, stderr=sp.STDOUT)
     os.makedirs(folder)
 
-    os.chdir(folder)
     extract_cmd = "7z x " + SCRIPTDIR + "/repositories.7z " + "-o" + folder + " " + os.path.join("test_repositories", bug_info['repo_owner'] + "--" + bug_info['repo_name'], bug_info['repo_name']) + "/*.* -r -y"
     sp.call(extract_cmd, shell=True, stdout=sp.DEVNULL, stderr=sp.STDOUT)
 


### PR DESCRIPTION
Related to https://github.com/bugsphp/bugsPHP/pull/2, now the first `chdir` seems unnecessary as well since the output path is given to all the following commands, and changing the directory to the output folder is not needed.